### PR TITLE
feat: add /infleta slash command with native Discord poll

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ from src.quote import quotefunc, qsearchfunc
 from src.nerdearla import nerdearlacharlasfunc
 from src.shithappens import ShitHappens
 from src.f1 import f1func
+from src.infleta import infletafun
 
 #IMPORT DE FUNCIONES PARA SISTEMA DE JOBS
 from src.jobsearch import jobsearchfunc
@@ -772,6 +773,7 @@ async def jobs(ctx, texto):
 async def f1(ctx, texto):
     await formula1ctxfunc(ctx, texto)
 
+
 #########################################################################################
 ################### LLAMADAS DE COMANDOS SLASH NATIVOS DISCORD (TREE) ###################
 
@@ -978,6 +980,25 @@ async def formula1(interaction: discord.Interaction, opcion: app_commands.Choice
             await interaction.followup.send(response, ephemeral=True)
     else:
         await interaction.followup.send("Hubo un error o el mensaje estaba vacío.", ephemeral=True)
+
+
+# COMANDO INFLETA (SLASH)
+@bot.tree.command(name="infleta", description="Crea encuesta de infleta (10 opciones / 8h)")
+@app_commands.describe(rango="Rango inicio-fin. Ej: 2 3 o 2,3")
+async def infleta_slash(interaction: discord.Interaction, rango: str):
+    try:
+        poll = await infletafun(interaction, rango)
+        await interaction.response.send_message(poll=poll)
+    except RuntimeError:
+        await interaction.response.send_message(
+            "Tu version de discord.py no soporta encuestas nativas. Actualiza a 2.4+ para usar /infleta.",
+            ephemeral=True,
+        )
+    except ValueError:
+        await interaction.response.send_message(
+            "Rango invalido. Usa: /infleta rango:'2 3'  o  /infleta rango:'2,3'",
+            ephemeral=True,
+        )
 
 # COMANDO JOB POST (NATIVO DISCORD)
 @bot.tree.command(name="jobpost", description="Postear un job (solo rol recruiter)")

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,9 +17,9 @@ click==8.1.8
 colorama==0.4.6
 contourpy==1.3.0
 cycler==0.12.1
-discord==2.3.2
+discord==2.4.0
 discord-ui==5.1.6
-discord.py==2.3.2
+discord.py==2.4.0
 dotenv-python==0.0.1
 et_xmlfile==2.0.0
 exceptiongroup==1.3.0

--- a/src/infleta.py
+++ b/src/infleta.py
@@ -1,0 +1,67 @@
+import discord
+from datetime import datetime, timedelta
+from decimal import Decimal, InvalidOperation
+
+
+def _parse_infleta_range(raw_input: str) -> tuple[Decimal, Decimal]:
+    cleaned = raw_input.strip()
+
+    # Soporta "2 3", "2,3" (como separador) y decimales con coma.
+    if " " in cleaned:
+        parts = [p.strip() for p in cleaned.split() if p.strip()]
+    else:
+        parts = [p.strip() for p in cleaned.split(",") if p.strip()]
+
+    if len(parts) != 2:
+        raise ValueError("Formato invalido")
+
+    try:
+        first = Decimal(parts[0].replace(",", "."))
+        second = Decimal(parts[1].replace(",", "."))
+    except InvalidOperation:
+        raise ValueError("Formato invalido")
+
+    if first >= second:
+        raise ValueError("Rango invalido")
+
+    return first, second
+
+
+def _format_decimal_spanish(value: Decimal) -> str:
+    normalized = value.quantize(Decimal("0.1"))
+    as_str = f"{normalized}"
+    if as_str.endswith(".0"):
+        as_str = as_str[:-2]
+    return as_str.replace(".", ",")
+
+
+def _build_infleta_options(start: Decimal, end: Decimal) -> list[str]:
+    step = (end - start) / Decimal("10")
+    if step <= 0:
+        raise ValueError("Rango invalido")
+
+    options = []
+    for index in range(10):
+        value = start + (step * Decimal(index))
+        options.append(_format_decimal_spanish(value))
+
+    return options
+
+
+async def infletafun(interaction: discord.Interaction, rango: str) -> discord.Poll:
+    if not hasattr(discord, "Poll"):
+        raise RuntimeError("discord.py sin soporte de Poll")
+
+    start, end = _parse_infleta_range(rango)
+    options = _build_infleta_options(start, end)
+
+    poll = discord.Poll(question="Valor de la infleta", duration=timedelta(hours=8))
+    for option in options:
+        poll.add_answer(text=option)
+
+    # Log
+    fecha_actual = datetime.now()
+    print(fecha_actual)
+    print(f"Se ha ejecutado el comando /infleta por {interaction.user}")
+
+    return poll


### PR DESCRIPTION
Agrega el comando /infleta que genera una encuesta nativa de Discord ("Valor de la infleta") con 10 opciones equidistantes y duración de 8h, a partir de un rango numérico (ej: /infleta 2 3 → 2, 2,1, ..., 2,9).

La lógica se aisló en src/infleta.py siguiendo el patrón existente (src/caucho.py, etc.). Se eliminó el comando !infleta por ser slash-only.

Se bumpeó discord.py 2.3.2 → 2.4.0 porque la API discord.Poll (encuestas nativas) no existe en versiones anteriores a 2.4.